### PR TITLE
Revert "Add not keyword"

### DIFF
--- a/pony.tmLanguage
+++ b/pony.tmLanguage
@@ -221,7 +221,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(if|ifdef|not|then|elseif|else|end|match|where|try|with|as|recover|consume|object|lambda|digestof)\b</string>
+					<string>\b(if|ifdef|then|elseif|else|end|match|where|try|with|as|recover|consume|object|lambda|digestof)\b</string>
 					<key>name</key>
 					<string>keyword.control.pony</string>
 				</dict>


### PR DESCRIPTION
Reverts ponylang/sublime-pony#4

The `not` keyword was already part of the grammar prior to this change, and now it's in two places.  This PR reverts the change.
