### PR TITLE
Update to remove lambda keyword (new syntax uses {}).

### DIFF
--- a/indent.tmPreferences
+++ b/indent.tmPreferences
@@ -15,7 +15,7 @@
 		<key>increaseIndentPattern</key>
 		<string>(?x)
 			 ^\s*(type|interface|trait|primitive|struct|class|actor|new|fun|be)\b.*$
-			|^.*\b(if|then|else|elseif|for|in|do|while|repeat|until|try|with|match|object|lambda|recover)\b((?!end).)*$
+			|^.*\b(if|then|else|elseif|for|in|do|while|repeat|until|try|with|match|object|recover)\b((?!end).)*$
 			|^.*=&gt;.*$
 		</string>
 		<key>indentParens</key>

--- a/pony.tmLanguage
+++ b/pony.tmLanguage
@@ -221,7 +221,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(if|ifdef|then|elseif|else|end|match|where|try|with|as|recover|consume|object|lambda|digestof)\b</string>
+					<string>\b(if|ifdef|then|elseif|else|end|match|where|try|with|as|recover|consume|object|digestof)\b</string>
 					<key>name</key>
 					<string>keyword.control.pony</string>
 				</dict>


### PR DESCRIPTION
This PR updates the syntax settings to remove the lambda keyword, because the new syntax for lambda uses curly braces.

See https://github.com/ponylang/ponyc/pull/1400.