### PR TITLE
Changed order of keyword patterns to enable ligature for =>

### DIFF
--- a/pony.tmLanguage
+++ b/pony.tmLanguage
@@ -251,13 +251,13 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>=</string>
+					<string>(\?|=&gt;)</string>
 					<key>name</key>
 					<string></string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(\?|=&gt;)</string>
+					<string>=</string>
 					<key>name</key>
 					<string></string>
 				</dict>


### PR DESCRIPTION
Assignment operator was matched before arrow which split => into two tokens
preventing the ligature from being applied.