### PR TITLE
Support annotations in type and function definitions

### DIFF
--- a/pony.tmLanguage
+++ b/pony.tmLanguage
@@ -97,16 +97,21 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.capability.pony</string>
+					<string>support.other.annotation.pony</string>
 				</dict>
 				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.capability.pony</string>
+				</dict>
+				<key>4</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.function.pony</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(new|be|fun)\s+(iso|trn|ref|val|box|tag)?\b\s*([_a-z][_a-zA-Z0-9]*)</string>
+			<string>\b(new|be|fun)\s+(\\[_a-z][_a-zA-Z0-9]*\\)?\s*(iso|trn|ref|val|box|tag)?\b\s*([_a-z][_a-zA-Z0-9]*)</string>
 		</dict>
 		<key>typedeclarations</key>
 		<dict>
@@ -120,16 +125,21 @@
 					<key>2</key>
 					<dict>
 						<key>name</key>
-						<string>keyword.other.capability.pony</string>
+						<string>support.other.annotation.pony</string>
 					</dict>
 					<key>3</key>
+					<dict>
+						<key>name</key>
+						<string>keyword.other.capability.pony</string>
+					</dict>
+					<key>4</key>
 					<dict>
 						<key>name</key>
 						<string>entity.name.type.pony</string>
 					</dict>
 				</dict>
 			<key>match</key>
-			<string>\b(type|interface|trait|primitive|struct|class|actor)\s+(iso|trn|ref|val|box|tag)?@?\s*([_A-Z][_a-zA-Z0-9]*)</string>
+			<string>\b(type|interface|trait|primitive|struct|class|actor)\s+(\\[_a-z][_a-zA-Z0-9]*\\)?\s*(iso|trn|ref|val|box|tag)?@?\s*([_A-Z][_a-zA-Z0-9]*)</string>
 		</dict>
 		<key>identifiers</key>
 		<dict>


### PR DESCRIPTION
Related to https://github.com/ponylang/pony-tutorial/issues/495, this should fix the syntax highlighting issues for Pony code in Github when using the `\nodoc\` annotation.

One caveat of the proposed solution is that it doesn't support multiple annotations, like so:

```pony
class \nodoc, nosupertype\ Foo
```

I didn't find an easy way to write a regular expression that matches a comma-separated list without using capture groups, which doesn't seem to be supported by Sublime's regex engine.
