### PR TITLE
Remove delegate keyword

### DIFF
--- a/pony.tmLanguage
+++ b/pony.tmLanguage
@@ -213,7 +213,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(var|let|embed|delegate)\b</string>
+					<string>\b(var|let|embed)\b</string>
 					<key>name</key>
 					<string>keyword.other.declaration.pony</string>
 				</dict>


### PR DESCRIPTION
Delegate support was removed in https://github.com/ponylang/ponyc/pull/1534 but we forgot to update the highlighter.